### PR TITLE
add linting configurations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,42 @@
+[flake8]
+# Moderate strictness configuration
+max-line-length = 88
+max-complexity = 10
+
+# Select specific error codes to check
+select = 
+    E,   # pycodestyle errors
+    W,   # pycodestyle warnings
+    F,   # pyflakes
+    C,   # mccabe complexity
+
+# Ignore some less critical issues for moderate strictness
+ignore = 
+    E203,  # whitespace before ':' (conflicts with black)
+    E501,  # line too long (handled by black)
+    W503,  # line break before binary operator (conflicts with black)
+    E402,  # module level import not at top of file (common in Flask apps)
+
+# Exclude common directories
+exclude = 
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    myenv,
+    env,
+    .env,
+    build,
+    dist,
+    .tox,
+    .pytest_cache,
+    *.egg-info
+
+# Show source code for each error
+show-source = True
+
+# Count errors
+count = True
+
+# Display which tool is being used
+verbose = 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,97 @@
+name: 🔍 Lint Code
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-frontend:
+    name: 🔧 Lint Frontend (TypeScript/JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: "browser-extension/package-lock.json"
+
+      - name: 📚 Install dependencies
+        working-directory: browser-extension
+        run: npm ci
+
+      - name: 🔍 Run ESLint
+        working-directory: browser-extension
+        run: npm run lint
+
+  lint-backend:
+    name: 🐍 Lint Backend (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: 📚 Install Python linting tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 black isort
+
+      - name: 🔍 Run flake8 (Style Guide Enforcement)
+        run: |
+          flake8 backend --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 backend --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+
+      - name: 🎨 Check code formatting with black
+        run: black --check --diff backend
+
+      - name: 📦 Check import sorting with isort
+        run: isort --check-only --diff backend
+
+  lint-configs:
+    name: 📝 Lint Configuration Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js (for markdownlint)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: 🐍 Setup Python (for yamllint)
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: 📚 Install linting tools
+        run: |
+          # YAML linting
+          pip install yamllint
+          # Markdown linting
+          npm install -g markdownlint-cli
+          # Dockerfile linting
+          wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          chmod +x hadolint
+          sudo mv hadolint /usr/local/bin/
+
+      - name: 🔧 Lint YAML files
+        run: yamllint -c .yamllint.yml .
+
+      - name: 📋 Lint Markdown files
+        run: markdownlint "**/*.md" --config .markdownlint.json --ignore node_modules
+
+      - name: 🐳 Lint Dockerfiles
+        run: |
+          find . -name "Dockerfile*" -not -path "./node_modules/*" -not -path "./.git/*" | xargs hadolint

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Linting cache files
+.eslintcache
+.markdownlintcache
+.flake8_cache/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+*.tmp
+*.temp
+*.log

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,37 @@
+{
+  "default": true,
+  "MD003": false,
+  "MD007": {
+    "indent": 2
+  },
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_block_line_length": 120,
+    "tables": false
+  },
+  "MD024": {
+    "allow_different_nesting": true
+  },
+  "MD029": {
+    "style": "ordered"
+  },
+  "MD033": {
+    "allowed_elements": [
+      "br",
+      "details",
+      "summary",
+      "img",
+      "a",
+      "div",
+      "span",
+      "kbd",
+      "sub",
+      "sup"
+    ]
+  },
+  "MD041": false,
+  "MD046": {
+    "style": "fenced"
+  }
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,60 @@
+---
+# YAML linting configuration - moderate strictness
+rules:
+  # Line length - be reasonable but not too strict
+  line-length:
+    max: 120
+    level: error
+
+  # Indentation - consistent spacing
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+
+  # Document formatting
+  document-start:
+    present: false # Don't require --- at start
+  document-end:
+    present: false # Don't require ... at end
+
+  # Comments
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: true
+
+  # Empty lines
+  empty-lines:
+    max: 2
+    max-start: 1
+    max-end: 1
+
+  # Brackets and braces
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+  # Trailing spaces
+  trailing-spaces: enable
+
+  # Key duplicates
+  key-duplicates: enable
+
+  # Truthy values - be flexible
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
+    check-keys: false
+
+# File patterns to check
+extends: default
+
+# Ignore patterns
+ignore: |
+  /.github/
+  /node_modules/
+  /.git/
+  /dist/
+  /build/

--- a/browser-extension/.eslintrc.js
+++ b/browser-extension/.eslintrc.js
@@ -1,0 +1,51 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    webextensions: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ["@typescript-eslint", "react", "react-hooks"],
+  rules: {
+    // Moderate strictness - errors only for important issues
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-non-null-assertion": "warn",
+
+    // General JavaScript/TypeScript rules
+    "no-console": "warn",
+    "no-debugger": "error",
+    "no-alert": "warn",
+    "prefer-const": "error",
+    "no-var": "error",
+
+    // React-specific rules (since using React in popup)
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+  ignorePatterns: [
+    "dist/",
+    "node_modules/",
+    "*.js", // Ignore compiled JS files
+  ],
+};

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -21,6 +21,8 @@
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
     "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "html-webpack-plugin": "^5.5.4",
     "style-loader": "^3.3.3",
     "ts-loader": "^9.5.1",


### PR DESCRIPTION
fixes #16 

This pull request adds a comprehensive linting setup for both frontend and backend code, as well as for configuration files. It introduces configuration files and tooling for ESLint (TypeScript/JavaScript), flake8 (Python), markdownlint (Markdown), yamllint (YAML), and hadolint (Dockerfiles). Additionally, it creates a GitHub Actions workflow to automate linting on every push or pull request to the main branch.

**Linting Workflow and Tooling Setup**

* Added `.github/workflows/lint.yml` workflow to automatically lint frontend (JavaScript/TypeScript), backend (Python), and configuration files (Markdown, YAML, Dockerfiles) on CI for every push or pull request to `main`.
* Updated `browser-extension/package.json` to include `eslint-plugin-react` and `eslint-plugin-react-hooks` as dependencies for improved React linting.

**Linting Configuration Files**

* Added `browser-extension/.eslintrc.js` with moderate strictness rules for TypeScript, React, and general JavaScript, including warnings/errors for unused variables, console statements, and React hooks usage.
* Added `.flake8` configuration to enforce Python style and complexity with selected error codes, exclusions, and compatibility with Black formatting.
* Added `.markdownlint.json` to configure Markdown linting rules, such as line length, allowed HTML elements, and ordered list styles.
* Added `.yamllint.yml` to set moderate strictness for YAML files, specifying rules for line length, indentation, comments, and ignored directories.